### PR TITLE
add feature C #1

### DIFF
--- a/R/kayaid.R
+++ b/R/kayaid.R
@@ -6,16 +6,22 @@
 #' @param gdp GDP per capita (in 1000$/person)
 #' @param enINT Energy Intensity (in Gigajoule/$1000GDP). Energy Intensity is the energy needed to produce a certain amount of economic value.
 #' @param carbInt Carbon Intensity (in tonnes CO2/Gigajoule). Carbon Intensity is the CO2 emitted for produced energy. This number depends on the energy mix used (coal, solar, . . . ).
+#' @param output_type If the option “C” is chosen, the results are given in tonnes C instead of tonnes CO2
 #' @return million tonnes of CO2 emissions
 #' @example
 #' kaya_identity(82.4, 44,5,0.05)
 #' @export
-kaya_identity <- function(pop, gdp, enInt, carbInt) {
+kaya_identity <- function(pop, gdp, enInt, carbInt, output_type = "CO2") {
   checkmate::assert_numeric(pop, lower = 0, any.missing = FALSE, len = 1)
   checkmate::assert_numeric(gdp, lower = 0, any.missing = FALSE, len = 1)
   checkmate::assert_numeric(enInt, lower = 0, any.missing = FALSE, len = 1)
   checkmate::assert_numeric(carbInt, lower = 0, any.missing = FALSE, len = 1)
+  checkmate::assert_choice(output_type, choices = c("CO2", "C"))
 
-  pop * gdp * enInt * carbInt
+  output <- if(output_type == "C") 1/3.67 else 1
+
+
+  pop * gdp * enInt * carbInt * output
 
 }
+

--- a/man/kaya_identity.Rd
+++ b/man/kaya_identity.Rd
@@ -4,7 +4,7 @@
 \alias{kaya_identity}
 \title{The Kaya Identity is an equation that expresses yearly CO2 emissions as a product of four factors}
 \usage{
-kaya_identity(pop, gdp, enInt, carbInt)
+kaya_identity(pop, gdp, enInt, carbInt, output_type = "CO2")
 }
 \arguments{
 \item{pop}{Population size (in millions)}

--- a/tests/testthat/test_kayaid.R
+++ b/tests/testthat/test_kayaid.R
@@ -3,8 +3,12 @@ context("test kaya")
 
 test_that("expect correct output", {
   set.seed(123)
-  co2emission <- do.call(kaya_identity, as.list(runif(4)))
+  values <- runif(4)
+  co2emission <- do.call(kaya_identity, as.list(values))
+  cemission <- do.call(kaya_identity, list(values[1], values[2], values[3], values[4], output_type = "C"))
   expect_more_than(co2emission, 0)
 
   expect_error(do.call(kaya_identity, as.list(runif(4, -2, -1))))
+
+  expect_equal(co2emission / cemission, 3.67)
 })


### PR DESCRIPTION
Adds a new argument output_type to your function, which can take on the options “CO2” and “C” (for Carbon), where “CO2” is the default. With option “CO2” the output remains the same. But when the option “C” is chosen, the results are given in tonnes C instead of tonnes CO2. 3.67 tonnes of CO2 equals 1 tonne of C. What do you get for the inputs of 4) as a result with output_type = “C”?